### PR TITLE
Improve memory usage of tracking line numbers of bytes

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -10,19 +10,29 @@ typedef enum {
   OP_RETURN,
 } OpCode;
 
+// used to mark the start of a new line in the source code
+typedef struct {
+  int offset; // mark the offset of the first instruction on that line
+  int line;   // track which line that instruction is on
+} LineStart;
+
 // dynamic array of bytes which holds our code
 typedef struct {
   int count; // count the number of bytes we have stored
   int capacity;
   uint8_t *code;
-  int *lines; // store the line number of each byte in the bytecode for
-              // outputting line number when runtime error occurs
   ValueArray constants;
+  int lineCount; // count how much is in lines since it will be different than
+                 // code because we will only increase lines when there is a
+                 // new line
+  int lineCapacity;
+  LineStart *lines;
 } Chunk;
 
 void initChunk(Chunk *chunk);
 void freeChunk(Chunk *chunk);
 void writeChunk(Chunk *chunk, uint8_t byte, int line);
 int addConstant(Chunk *chunk, Value value);
+int getLine(Chunk *chunk, int offset);
 
 #endif

--- a/debug.c
+++ b/debug.c
@@ -38,13 +38,14 @@ int disassembleInstruction(Chunk *chunk, int offset) {
   // print the byte offset of the given instruction
   // indicates where in the chunk this instruction is
   printf("offset: %04d...", offset);
+  int line = getLine(chunk, offset);
 
-  if (offset > 0 && chunk->lines[offset] == chunk->lines[offset - 1]) {
+  if (offset > 0 && line == getLine(chunk, offset - 1)) {
     // we show | for any instruction that comes from the same source line as the
     // preceding one
     printf("    | ");
   } else {
-    printf("line-number: %4d...", chunk->lines[offset]);
+    printf("line-number: %4d...", line);
   }
 
   // read a single byte from the bytecode at the given offset to get the opcode


### PR DESCRIPTION
Since multiple instructions can come from the same line of source code, we can track just the byte offset and line number of the first byte of that line.

Then when we want to print out the line number, we look for the closest offset via binary search and return the line number that the closest offset appears on.

In the initial implementation, we tracked the line number for every byte.

This new way reduces the amount of data we have to record thereby improving memory usage.