### PR TITLE
Add OP_CONSTANT_LONG to allow for more than 256 constants

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -7,6 +7,7 @@
 
 typedef enum {
   OP_CONSTANT,
+  OP_CONSTANT_LONG,
   OP_RETURN,
 } OpCode;
 
@@ -34,5 +35,6 @@ void freeChunk(Chunk *chunk);
 void writeChunk(Chunk *chunk, uint8_t byte, int line);
 int addConstant(Chunk *chunk, Value value);
 int getLine(Chunk *chunk, int offset);
+void writeConstant(Chunk *chunk, Value value, int line);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -8,7 +8,8 @@ int main(int argc, const char *argv[]) {
   int constant = addConstant(&chunk, 1.2);
   writeChunk(&chunk, OP_CONSTANT, 123);
   writeChunk(&chunk, constant, 123);
-  writeChunk(&chunk, OP_RETURN, 123);
+  writeConstant(&chunk, 20, 125);
+  writeChunk(&chunk, OP_RETURN, 126);
   disassembleChunk(&chunk, "test chunk");
   freeChunk(&chunk);
   return 0;


### PR DESCRIPTION
OP_CONSTANT only uses a single byte for its operand. This allows for 256 constants. To store more, we introduce a different opcode, OP_CONSTANT_LONG, which stores its operand as a 24-bit number to allow for much more constants in the code